### PR TITLE
chore/docs: README quick-wins, CI on dev/staging, PR template, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for this repository
+# Adjust as needed
+* @MarcoPWx
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Pull Request Checklist
+
+Thanks for contributing! Before requesting review:
+
+- [ ] Base branch is `dev`
+- [ ] Title is conventional (feat|fix|docs|chore|ci): short summary
+- [ ] CI (lint, unit, Storybook build, a11y, E2E) passes
+- [ ] README/docs updated if user-facing changes
+- [ ] Stories and tests added/updated as needed
+
+Deployment flow reminder:
+- Merge into `dev`
+- Promote via PR: `dev` → `staging` (CI required)
+- Promote via PR: `staging` → `main` (CI required)
+


### PR DESCRIPTION
This PR targets dev. Includes:
- README quick wins (requirements, command cheatsheet, common issues, real API tip)
- CI workflow runs on dev/staging, disables Storybook telemetry in CI
- PR template and CODEOWNERS (default @MarcoPWx)

After merge to dev, CI should pass. We’ll keep working on dev, then promote dev → staging (required checks) and staging → main (required checks).