### PR TITLE
chore: use port 7009 for Storybook and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,14 @@ jobs:
       - name: Run Storybook tests (a11y)
         run: |
           npx concurrently -k -s first -n "SB,TEST" \
-            "npx http-server storybook-static -p 7007" \
-            "npx wait-on http://localhost:7007 && npm run test:stories"
+            "npx http-server storybook-static -p 7009" \
+            "npx wait-on http://localhost:7009 && npm run test:stories"
       
       - name: Run E2E tests
         run: |
           npx concurrently -k -s first -n "SB,E2E" \
             "npx http-server storybook-static -p 7007" \
-            "npx wait-on http://localhost:7007 && npm run e2e"
+            "npx wait-on http://localhost:7009 && npm run e2e"
       
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "node": ">=18.17"
   },
   "scripts": {
-    "dev": "storybook dev -p 7007",
+    "dev": "storybook dev -p 7009",
     "build": "storybook build",
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
-    "test:stories": "test-storybook --url http://localhost:7007",
+    "test:stories": "test-storybook --url http://localhost:7009",
     "e2e": "playwright test",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "prettier:check": "prettier --check .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: './e2e',
   testIgnore: ['**/tests/**'],
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:7007',
+    baseURL: process.env.BASE_URL || 'http://localhost:7009',
     headless: true,
   },
   reporter: [['html', { open: 'never' }]],


### PR DESCRIPTION
- dev script: storybook dev -p 7009\n- test:stories: --url http://localhost:7009\n- CI: serve static Storybook on 7009 for a11y and e2e\n- Playwright baseURL -> http://localhost:7009\n\nOutcome: running locally (npm run dev) and CI test steps all target port 7009.