### PR TITLE
style(stories): center layout, soft backgrounds, and DevLogLive component

### DIFF
--- a/src/stories/API/Playground.stories.tsx
+++ b/src/stories/API/Playground.stories.tsx
@@ -4,6 +4,16 @@ import ApiPlayground from "./ApiPlayground";
 const meta: Meta<typeof ApiPlayground> = {
   title: "API/Playground",
   component: ApiPlayground,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f8fafc' },
+        { name: 'dark', value: '#0f172a' },
+      ],
+    },
+  },
 };
 export default meta;
 

--- a/src/stories/Dev/NetworkPlayground.stories.tsx
+++ b/src/stories/Dev/NetworkPlayground.stories.tsx
@@ -4,6 +4,16 @@ import NetworkPlayground from "./NetworkPlayground";
 const meta: Meta<typeof NetworkPlayground> = {
   title: "Dev/NetworkPlayground",
   component: NetworkPlayground,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f8fafc' },
+        { name: 'dark', value: '#0f172a' },
+      ],
+    },
+  },
 };
 export default meta;
 

--- a/src/stories/Docs/DevLogLive.stories.tsx
+++ b/src/stories/Docs/DevLogLive.stories.tsx
@@ -4,11 +4,17 @@ import DevLogLive from './DevLogLive'
 // Hidden legacy story: we keep a valid CSF default export to satisfy Storybook indexer
 // but push it to the bottom of the sidebar.
 const meta: Meta<typeof DevLogLive> = {
-  title: 'ZZZ/Hidden/Dev Log (Live)',
+  title: 'Docs/Dev Log (Live)',
   component: DevLogLive,
   parameters: {
-    docs: { autodocs: false },
-    options: { showPanel: false },
+    layout: 'centered',
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f8fafc' },
+        { name: 'dark', value: '#0f172a' },
+      ],
+    },
   },
 }
 

--- a/src/stories/Docs/DevLogLive.tsx
+++ b/src/stories/Docs/DevLogLive.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+
+// Minimal live Dev Log panel. If docs/status/DEVLOG.md exists in your public staticDir,
+// this will attempt to fetch and render a snippet. Otherwise, it shows helpful guidance.
+const DevLogLive: React.FC = () => {
+  const [content, setContent] = useState<string>('')
+  const [error, setError] = useState<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/status/DEVLOG.md')
+        if (!res.ok) throw new Error(String(res.status))
+        const txt = await res.text()
+        if (!cancelled) setContent(txt)
+      } catch (e) {
+        if (!cancelled) setError('Dev Log not found (docs/status/DEVLOG.md).')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div style={{ maxWidth: 960, margin: '40px auto', padding: 24, background: '#fff', borderRadius: 8, boxShadow: '0 10px 30px rgba(0,0,0,0.08)' }}>
+      <h2 style={{ marginTop: 0 }}>Dev Log (Live)</h2>
+      {content ? (
+        <pre style={{ whiteSpace: 'pre-wrap' }}>{content.slice(0, 2000)}</pre>
+      ) : (
+        <p style={{ color: '#475569' }}>
+          {error || 'Loading...' }<br/>
+          Place your markdown at <code>docs/status/DEVLOG.md</code> to show real content here.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default DevLogLive
+

--- a/src/stories/Epics/EpicManagerImproved.stories.tsx
+++ b/src/stories/Epics/EpicManagerImproved.stories.tsx
@@ -2,9 +2,19 @@ import type { Meta, StoryObj } from "@storybook/react";
 import EpicManager from "./EpicManager";
 
 const meta: Meta<typeof EpicManager> = {
-  title: "Epics/Epic Manager (Improved)",
+  title: 'Epics/Epic Manager (Improved)',
   component: EpicManager,
-};
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f8fafc' },
+        { name: 'dark', value: '#0f172a' },
+      ],
+    },
+  },
+}
 export default meta;
 
 export const Default: StoryObj<typeof EpicManager> = {};

--- a/src/stories/Status/StatusDashboard.stories.tsx
+++ b/src/stories/Status/StatusDashboard.stories.tsx
@@ -4,6 +4,16 @@ import StatusDashboard from "./StatusDashboard";
 const meta: Meta<typeof StatusDashboard> = {
   title: "Status/StatusDashboard",
   component: StatusDashboard,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#f8fafc' },
+        { name: 'dark', value: '#0f172a' },
+      ],
+    },
+  },
 };
 export default meta;
 


### PR DESCRIPTION
Visual polish for baseline stories so they don’t look rough out-of-the-box.\n\nChanges\n- Add Docs/DevLogLive.tsx (safe live panel that fetches docs/status/DEVLOG.md if present)\n- Center layout + soft backgrounds for: API/Playground, Dev/NetworkPlayground, Status/StatusDashboard, Epics/EpicManager (Improved)\n- Keep component logic untouched; this is purely presentation/layout in stories\n\nPort\n- Still using 7009 across dev/CI/Playwright.